### PR TITLE
Add stack.yaml

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,7 @@
+resolver: lts-12.20
+packages:
+- .
+- location:
+    git: https://github.com/rd--/hosc.git
+    commit: master
+  extra-dep: true


### PR DESCRIPTION
This enables users of the Stack build tool to work on the latest development build.
It also uses the latest commit on hosc's master branch.